### PR TITLE
Improve square styles and props

### DIFF
--- a/src/components/GameScreen.jsx
+++ b/src/components/GameScreen.jsx
@@ -84,7 +84,9 @@ const GameScreen = ({ gameState, onMove, onLeaveGame }) => {
               isOldest={isOldestPiece(index)}
               isDisabled={!canPlaySquare(index)}
               onClick={onMove}
-            />
+            >
+              {square}
+            </Square>
           ))}
         </section>
 

--- a/src/components/Square.jsx
+++ b/src/components/Square.jsx
@@ -1,6 +1,6 @@
-const Square = ({ value, index, isOldest, isDisabled, onClick, isSelected }) => {
-  const valueClass = value === 'X' ? 'x' : value === 'O' ? 'o' : ''
-  const className = `square ${valueClass} ${isSelected ? 'is-selected' : ''} ${isOldest ? 'oldest' : ''} ${isDisabled ? 'disabled' : ''}`
+const Square = ({ value, index, isOldest, isDisabled, onClick, isSelected, children }) => {
+  const symbolClass = value === 'X' ? 'x' : value === 'O' ? 'o' : ''
+  const className = `square ${symbolClass} ${isSelected ? 'is-selected' : ''} ${isOldest ? 'oldest' : ''} ${isDisabled ? 'disabled' : ''}`
 
   const handleClick = () => {
     if (!isDisabled && onClick) {
@@ -10,7 +10,7 @@ const Square = ({ value, index, isOldest, isDisabled, onClick, isSelected }) => 
 
   return (
     <div onClick={handleClick} className={className}>
-      {value}
+      <span className="symbol">{children}</span>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -130,12 +130,12 @@ body {
   box-shadow: 0 0 10px #fff, inset 0 0 10px #fff;
 }
 
-.square.x {
+.square.x .symbol {
   color: rgb(0, 89, 255);
   text-shadow: 0 0 5px #0ff, 0 0 10px rgb(0, 89, 255);
 }
 
-.square.o {
+.square.o .symbol {
   color: #f44;
   text-shadow: 0 0 5px #f44, 0 0 10px #f44;
 }
@@ -153,7 +153,10 @@ body {
 
 .square.oldest {
   border-color: #ff4444;
-  animation: pulse-border 1.5s infinite, blink 1s step-start infinite;
+}
+
+.square.oldest .symbol {
+  animation: blink 1s steps(2, start) infinite;
 }
 
 @keyframes pulse-border {


### PR DESCRIPTION
## Summary
- pass `value` prop to `<Square>` and show children
- style `.square.x`/`.square.o` with glow via `.symbol`
- blink animation on oldest square pieces

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d558756fc8327a38340859ccf3679